### PR TITLE
Bugfix/38

### DIFF
--- a/src/styles/components/recruit-card.module.scss
+++ b/src/styles/components/recruit-card.module.scss
@@ -91,6 +91,7 @@
   font-size: 1.65rem;
   font-weight: 600;
   color: var(--grey800);
+  height: calc(1.65rem * 1.4 * 2);
 }
 
 .card__position,

--- a/src/styles/components/recruit-card.module.scss
+++ b/src/styles/components/recruit-card.module.scss
@@ -125,7 +125,7 @@
 .card__title__container,
 .card__date__container {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   column-gap: 0.5rem;
 }
 


### PR DESCRIPTION
## PR for Issue https://github.com/klmhyeonwoo/awesome-dori/issues/38

### 목적
- 채용공고 카드 제목 길이에 따른 높이 불일치 현상 수정
- 제목 아이콘의 부자연스러운 중앙정렬 문제 해결

### 주요 변경사항

1. **카드 높이 일관성 확보**
   - `card__title` 높이를 `calc(1.65rem * 1.4 * 2)`로 고정
   - 폰트 크기 변경 시에도 비율 유지되는 반응형 설계
   - 1줄/2줄 제목 관계없이 동일한 높이 보장

2. **아이콘 정렬 개선**
   - `align-items: center` → `align-items: flex-start`
   - 아이콘이 제목의 첫 번째 줄에 정렬되도록 수정
   - 멀티라인 제목에서 더 자연스러운 시각적 배치

### Before/After
- Before
![Screenshot 2025-05-28 at 2 36 16 AM](https://github.com/user-attachments/assets/d422e471-9f68-4f6f-bb04-7e3ca09cd215)
- After
![Screenshot 2025-05-28 at 2 37 52 AM](https://github.com/user-attachments/assets/9bee0ebb-d7aa-4e70-947b-e5aec06cc5a3)