### PR TITLE
fix: add type declarations for GIF, PNG, and SVG to fix TS2307 errors

### DIFF
--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -11,6 +11,9 @@ declare module "*.png" {
   export default src;
 }
 declare module "*.svg" {
+  export const ReactComponent: React.FunctionComponent<
+    React.SVGProps<SVGSVGElement>
+  >;
   const src: string;
   export default src;
 }

--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -2,3 +2,15 @@ declare module "*.mp4" {
   const src: string;
   export default src;
 }
+declare module "*.gif" {
+  const src: string | StaticImageData;
+  export default src;
+}
+declare module "*.png" {
+  const src: string |StaticImageData
+  export default src;
+}
+declare module "*.svg" {
+  const src: string;
+  export default src;
+}


### PR DESCRIPTION
- Added declarations.d.ts to define modules for *.gif, *.png, and *.svg
- Allows importing public folder images without TypeScript errors

**Before**
<img width="1410" height="751" alt="스크린샷 2025-08-22 오후 1 09 20" src="https://github.com/user-attachments/assets/abccfa8a-ab3d-41cc-9bc6-82dea6b540fa" />

**After**
<img width="1410" height="751" alt="image" src="https://github.com/user-attachments/assets/403fe01a-26a0-459d-af73-2fdd08c30a31" />
